### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ ADXL	KEYWORD1
 
 initialize	KEYWORD2
 readAccel	KEYWORD2
-get_Gxyz KEYWORD2
+get_Gxyz	KEYWORD2
 setTapThreshold	KEYWORD2
 getTapThreshold	KEYWORD2
 setAxixGains	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords